### PR TITLE
Use alternate dockerui image due to hub removal

### DIFF
--- a/src/fleet/dockerui.service
+++ b/src/fleet/dockerui.service
@@ -7,12 +7,12 @@ Requires=docker.service
 User=core
 TimeoutStartSec=0
 EnvironmentFile=/etc/environment
-ExecStartPre=-/usr/bin/docker pull dockerui/dockerui:latest
+ExecStartPre=-/usr/bin/docker pull abh1nav/dockerui:latest
 ExecStartPre=-/usr/bin/docker rm dockerui
 ExecStart=/usr/bin/docker run --rm --name dockerui --memory="128m" \
  -p 9000:9000 \
  -v /var/run/docker.sock:/docker.sock \
- dockerui/dockerui -e /docker.sock
+ abh1nav/dockerui -e /docker.sock
 #
 ExecStop=/usr/bin/docker stop dockerui
 ExecStopPost=-/usr/bin/docker rm dockerui


### PR DESCRIPTION
Work around https://github.com/crosbymichael/not-dockers-ui/issues/200 until an "official" unofficial dockerui becomes available